### PR TITLE
HED integration

### DIFF
--- a/integrateCTAGGER.m
+++ b/integrateCTAGGER.m
@@ -1,0 +1,90 @@
+function [dataStruct, tags] = integrateCTAGGER(dataStruct, varargin)
+
+    jarFile = fullfile(pwd, 'CTagger.jar');
+    if ~ismember(jarFile, javaclasspath('-dynamic'))
+        javaaddpath(jarFile);
+    end
+    % Parse input arguments
+    p = parseArguments(dataStruct, varargin{:});
+    
+    % Step 1: Load JSON
+    if ~isempty(p.sidecar) && exist(p.sidecar, 'file')
+        tags = fileread(p.sidecar); % Read directly from the file
+    else
+        % Hardcoded default JSON with proper formatting for MATLAB
+        tags = ['{' ...
+                   '"onset":{"Description":"Time at which the event occurred, in seconds.","Units":"seconds"},' ...
+                   '"duration":{"Description":"Duration of the event, in seconds.","Units":"seconds"},' ...
+                   '"trial_type":{"Description":"Type of trial.","Levels":{' ...
+                       '"stimulus":"Event indicating stimulus",' ...
+                       '"response":"Event indicating response"' ...
+                   '}}' ...
+               '}'];
+    end
+
+    % Step 2: Pass JSON to CTAGGER
+    try
+        [tags, canceled] = useCTAGGER(tags);
+        
+        if canceled
+            disp('Tagging process canceled.');
+            return;
+        end
+    catch ME
+        error('CTAGGER Error: %s', ME.message);
+    end
+
+    % Step 3: Update the data structure
+    dataStruct.tags = tags;
+    disp('Tagging complete.');
+end
+
+function [tags, canceled] = useCTAGGER(tags)
+    % Wrapper for launching CTAGGER
+    canceled = false;
+    [newTags, canceled] = loadCTAGGER(tags);
+    if ~canceled
+        tags = newTags;
+    end
+end
+
+function [result, canceled] = loadCTAGGER(json)
+    % Launch CTAGGER
+    canceled = false;
+    notified = false;
+
+    try
+        loader = javaObject('TaggerLoader', json);
+    catch ME
+        error('Error initializing CTAGGER: %s', ME.message);
+    end
+
+    % Wait for user interaction
+    timeout = 300; % seconds
+    tStart = tic;
+    while ~notified && toc(tStart) < timeout
+        pause(0.5);
+        notified = loader.isNotified();
+    end
+
+    if ~notified
+        error('CTAGGER did not respond within the timeout period.');
+    end
+
+    % Check if tagging was canceled
+    if loader.isCanceled()
+        canceled = true;
+        result = '';
+    else
+        result = char(loader.getHEDJson());
+    end
+end
+
+function p = parseArguments(dataStruct, varargin)
+    % Parse input arguments
+    parser = inputParser;
+    parser.addRequired('dataStruct', @(x) isstruct(x));
+    parser.addParameter('sidecar', '', @ischar); % Add 'sidecar' as a recognized parameter
+    parser.parse(dataStruct, varargin{:});
+    p = parser.Results;
+end

--- a/process_grouphed.m
+++ b/process_grouphed.m
@@ -1,0 +1,118 @@
+function varargout = process_group_by_hed(varargin)
+    % Process to group events by HED tags in Brainstorm
+
+    eval(macro_method);
+end
+
+%% ===== GET DESCRIPTION =====
+function sProcess = GetDescription()
+    % Description of the process
+    sProcess.Comment = 'Group Events by HED Tags';
+    sProcess.Category = 'Custom';
+    sProcess.SubGroup = 'User';
+    sProcess.Index = 1002; 
+    sProcess.isSeparator = 1;
+
+    % Define the input and output types
+    sProcess.InputTypes = {'data', 'raw'};
+    sProcess.OutputTypes = {'data', 'raw'};
+    sProcess.nInputs = 1;
+    sProcess.nMinFiles = 1;
+
+    % Add options for user configuration 
+    sProcess.options.showOutput.Comment = 'Display grouped events in a message box';
+    sProcess.options.showOutput.Type = 'checkbox';
+    sProcess.options.showOutput.Value = 1;
+end
+
+%% ===== FORMAT COMMENT =====
+function Comment = FormatComment(sProcess)
+    Comment = sProcess.Comment;
+end
+
+%% ===== RUN =====
+function OutputFiles = Run(sProcess, sInput)
+    % Initialize output file list
+    OutputFiles = {};
+
+    % Check for exactly one input file
+    if length(sInput) ~= 1
+        bst_report('Error', sProcess, sInput, 'This process requires exactly one input file.');
+        return;
+    end
+
+    % Load the input data structure
+    DataStruct = in_bst_data(sInput.FileName);
+    if ~isfield(DataStruct, 'Events') || isempty(DataStruct.Events)
+        bst_report('Error', sProcess, sInput, 'No events found in the data.');
+        return;
+    end
+
+    % Extract events
+    events = DataStruct.Events;
+
+    % Group events by HED tags
+    try
+        groupedEvents = groupEventsByHEDTags(events);
+    catch ME
+        bst_report('Error', sProcess, sInput, ['Error grouping events: ' ME.message]);
+        return;
+    end
+
+    % Optionally display grouped events
+    if sProcess.options.showOutput.Value
+        DisplayGroupedEvents(groupedEvents);
+    end
+
+    % No output modification needed; return input file
+    OutputFiles{1} = sInput.FileName;
+end
+
+function groupedEvents = groupEventsByHEDTags(events)
+    % Groups events based on their HED tags
+    %
+    % Input:
+    %   events - Array of event structures with HED tags
+    % Output:
+    %   groupedEvents - Struct where each field is a unique HED tag, and its
+    %                   value is an array of event indices
+
+    tagMap = containers.Map('KeyType', 'char', 'ValueType', 'any');
+
+    for i = 1:length(events)
+        % Extract the HED tags for this event
+        if ~isfield(events(i), 'hedTags') || isempty(events(i).hedTags)
+            continue; 
+        end
+
+        % Assume hedTags is a comma-separated string; split into individual tags
+        hedTags = strsplit(events(i).hedTags, ',');
+        hedTags = strtrim(hedTags); 
+
+        % Group by each tag
+        for j = 1:length(hedTags)
+            tag = hedTags{j};
+            if ~isKey(tagMap, tag)
+                tagMap(tag) = []; % Initialize empty group
+            end
+            tagMap(tag) = [tagMap(tag), i]; % Add event index to group
+        end
+    end
+
+    % Convert map to struct for easier access
+    groupedEvents = struct();
+    tagKeys = keys(tagMap);
+    for k = 1:length(tagKeys)
+        groupedEvents.(matlab.lang.makeValidName(tagKeys{k})) = tagMap(tagKeys{k});
+    end
+end
+
+function DisplayGroupedEvents(groupedEvents)
+    % Display grouped events in a message box
+    msg = 'Grouped Events by HED Tags:\n';
+    tagNames = fieldnames(groupedEvents);
+    for i = 1:length(tagNames)
+        msg = sprintf('%s\n%s: [%s]', msg, tagNames{i}, num2str(groupedEvents.(tagNames{i})));
+    end
+    msgbox(msg, 'Grouped Events', 'help');
+end

--- a/testCTagger.m
+++ b/testCTagger.m
@@ -1,0 +1,20 @@
+% Load the events.json file
+eventsJsonFile = 'events.json';
+
+if exist(eventsJsonFile, 'file')
+    disp('Using events.json as input...');
+    sidecar = eventsJsonFile;
+else
+    sidecar = '';
+end
+
+%example data structure
+dataStruct.events = struct('onset', {0.5, 1.0, 1.5}, ...
+                           'duration', {0.5, 0.5, 0.5}, ...
+                           'trial_type', {'stimulus', 'response', 'stimulus'});
+
+% Integrate CTAGGER
+[dataStruct, tags] = integrateCTAGGER(dataStruct, 'sidecar', sidecar);
+
+disp('Updated JSON:');
+disp(tags);


### PR DESCRIPTION
- testCTAGGER.m:
A script to test the integration of CTAGGER with HED tags using example data structures and an external events.json file.

- integrateCTAGGER.m:
A function to handle the integration of CTAGGER into Brainstorm workflows, including the ability to read HED-tagged events and allow the user to modify them through CTAGGER.

- process_grouphed.m:
Brainstorm process to group events based on HED tags and display them in a structured format. 